### PR TITLE
feat: restrict mfe access based on tags

### DIFF
--- a/SSR-catalog-example/catalog-mfe/template.yaml
+++ b/SSR-catalog-example/catalog-mfe/template.yaml
@@ -18,6 +18,10 @@ Parameters:
   DDBProductsTable:
     Type: String
     Default: ProductsTable
+  MFENamespace:
+    Type: String
+    Description: The namespace to use for the mfe tag
+    Default: demo
 
 Resources:
 
@@ -63,6 +67,8 @@ Resources:
             TableName: !Ref DynamoTable
         - DynamoDBReadPolicy:
             TableName: !Ref ProductsTable
+      Tags:
+        mfe: !Sub ${MFENamespace}.catalog
 
   ProductFunction:
     Type: AWS::Serverless::Function

--- a/SSR-catalog-example/reviews-mfe/template.yaml
+++ b/SSR-catalog-example/reviews-mfe/template.yaml
@@ -4,7 +4,14 @@ Description: >
   reviews-mfe
 
   Sample SAM Template for reviews-mfe
-  
+
+
+Parameters:
+  MFENamespace:
+    Type: String
+    Description: The namespace to use for the mfe tag
+    Default: demo
+
 Globals:
   Function:
     Timeout: 30
@@ -52,6 +59,8 @@ Resources:
           Properties:
             Path: /review
             Method: post
+      Tags:
+        mfe: !Sub ${MFENamespace}.reviews
   ReviewsMFEFunction:
     Type: AWS::Serverless::Function
     Properties:
@@ -60,6 +69,8 @@ Resources:
       Policies:
         - DynamoDBReadPolicy:
             TableName: !Ref ReviewsTable
+      Tags:
+        mfe: !Sub ${MFENamespace}.reviews
   ServiceDiscoveryID:
     Type: AWS::SSM::Parameter
     Properties:
@@ -74,7 +85,7 @@ Resources:
       Policies:
         - DynamoDBCrudPolicy:
             TableName: !Ref ReviewsTable
-  
+
   DeploymentCustomResource:
     Type: Custom::AppConfiguration
     Properties:

--- a/SSR-catalog-example/ui-composer/lib/ui-composer-stack.ts
+++ b/SSR-catalog-example/ui-composer/lib/ui-composer-stack.ts
@@ -95,7 +95,12 @@ export class UiComposerStack extends Stack {
               resources: [
                 `arn:aws:lambda:${process.env.region || "eu-west-1"}:${account.accountId}:function:*`,
                 `arn:aws:states:${process.env.region || "eu-west-1"}:${account.accountId}:stateMachine:*`
-              ]
+              ],
+              conditions: {
+                'StringLike': {
+                  "aws:ResourceTag/mfe": `${process.env.MFE_NAMESPACE ?? "demo"}.*`,
+                },
+              }
             }),
             new aws_iam.PolicyStatement({
               effect: aws_iam.Effect.ALLOW,


### PR DESCRIPTION
*Issue #, if available:*
N/A
*Description of changes:*
Restricts UI composer access to MFE lambdas/state machines which have the **mfe** tag present and set to a value beginning with the defined "namespace". 

For example, using the default namespace of `demo`, the UI composer will only be able to call **InvokeFunction** or **StartSyncExecution** if the function/state machine has the tag **mfe** with a value like **demo.*foo*** where *foo* can be any string, such as catalog or reviews.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
